### PR TITLE
fix: correct nokogiri dependency version

### DIFF
--- a/algolia_html_extractor.gemspec
+++ b/algolia_html_extractor.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
 
   # Dependencies
   gem.add_runtime_dependency 'json', '~> 2.0'
-  gem.add_runtime_dependency 'nokogiri', '~> 1.10.4'
+  gem.add_runtime_dependency 'nokogiri', '>= 1.10.4'
 
   gem.add_development_dependency 'coveralls', '~> 0.8.21'
   gem.add_development_dependency 'flay', '~> 2.6'


### PR DESCRIPTION
This PR updates the dependency version so it as at least 1.10.4 instead of ~> 1.10.4.