### PR TITLE
fix: nokogiri version bump

### DIFF
--- a/algolia_html_extractor.gemspec
+++ b/algolia_html_extractor.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
 
   # Dependencies
   gem.add_runtime_dependency 'json', '~> 2.0'
-  gem.add_runtime_dependency 'nokogiri', '>= 1.10.4'
+  gem.add_runtime_dependency 'nokogiri', '~> 1.10'
 
   gem.add_development_dependency 'coveralls', '~> 0.8.21'
   gem.add_development_dependency 'flay', '~> 2.6'

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -3,6 +3,6 @@
 # Expose gem version
 # rubocop:disable Style/SingleLineMethods
 class AlgoliaHTMLExtractorVersion
-  def self.to_s; '2.6.2' end
+  def self.to_s; '2.6.3' end
 end
 # rubocop:enable Style/SingleLineMethods


### PR DESCRIPTION
This PR allows for Nokogiri versions >= 1.10 but < 2.0.

